### PR TITLE
restoring original abilities using Pokemon.persistentData and removing italic from megastones names

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     modImplementation("com.google.code.findbugs:jsr305:3.0.2")
     modCompileOnly("com.cobblemon:mod:${rootProject.property("cobblemon_version")}") {
         isTransitive = false
+        isChanging = true
     }
     modApi(libs.architectury)
 
@@ -36,4 +37,8 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+configurations.all {
+    resolutionStrategy.cacheChangingModulesFor(0, TimeUnit.SECONDS)
 }

--- a/common/src/main/java/com/selfdot/cobblemonmegas/common/DataKeys.java
+++ b/common/src/main/java/com/selfdot/cobblemonmegas/common/DataKeys.java
@@ -10,8 +10,8 @@ public class DataKeys {
     public static final String MEGA_Y = "mega-y";
     public static final String NBT_KEY_MEGA_STONE = "megaStone";
     public static final String NBT_KEY_KEY_STONE = "keyStone";
+    public static final String NBT_KEY_PREVIOUS_ABILITY = "previousAbility";
     public static final String MEGA_STONE_WHITELIST = "megaStoneWhitelist";
     public static final String MEGA_RAYQUAZA_ALLOWED = "megaRayquazaAllowed";
     public static final Identifier COBBLEMON_KEY_STONE = Identifier.of("cobblemon", "key_stone");
-
 }

--- a/common/src/main/java/com/selfdot/cobblemonmegas/common/command/MegaEvolveSlotCommand.java
+++ b/common/src/main/java/com/selfdot/cobblemonmegas/common/command/MegaEvolveSlotCommand.java
@@ -1,6 +1,5 @@
 package com.selfdot.cobblemonmegas.common.command;
 
-import com.cobblemon.mod.common.api.abilities.Ability;
 import com.cobblemon.mod.common.api.battles.model.PokemonBattle;
 import com.cobblemon.mod.common.api.battles.model.actor.BattleActor;
 import com.cobblemon.mod.common.api.pokemon.feature.FlagSpeciesFeature;
@@ -18,10 +17,6 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
-
 public class MegaEvolveSlotCommand implements Command<ServerCommandSource> {
 
     @Override
@@ -31,9 +26,7 @@ public class MegaEvolveSlotCommand implements Command<ServerCommandSource> {
 
         Pokemon pokemon = PartySlotArgumentType.Companion.getPokemon(context, "pokemon");
 
-        if (Stream.of(DataKeys.MEGA, DataKeys.MEGA_X, DataKeys.MEGA_Y)
-            .anyMatch(aspect -> pokemon.getAspects().contains(aspect))
-        ) {
+        if (MegaUtils.containsMegaAspects(pokemon)) {
             MegaUtils.deMegaEvolve(pokemon);
             return SINGLE_SUCCESS;
         }
@@ -60,9 +53,8 @@ public class MegaEvolveSlotCommand implements Command<ServerCommandSource> {
 
         PokemonBattle battle = BattleRegistry.INSTANCE.getBattleByParticipatingPlayer(player);
         if (battle == null) {
-            // Save the original ability to restore it later
-            ConcurrentHashMap<UUID, Ability> originalAbilities = CobblemonMegas.getInstance().getOriginalAbilities();
-            originalAbilities.put(pokemon.getUuid(), pokemon.getAbility());
+            // Save the ability to restore it later
+            MegaUtils.savePreviousAbility(pokemon);
 
             new FlagSpeciesFeature(megaType, true).apply(pokemon);
         } else {

--- a/common/src/main/java/com/selfdot/cobblemonmegas/common/item/MegaStoneHeldItemManager.java
+++ b/common/src/main/java/com/selfdot/cobblemonmegas/common/item/MegaStoneHeldItemManager.java
@@ -37,13 +37,12 @@ public class MegaStoneHeldItemManager implements HeldItemManager {
         ItemStack megaStone = new ItemStack(Items.EMERALD);
         NbtUtils.setNbtString(megaStone, "", DataKeys.NBT_KEY_MEGA_STONE, id);
         NbtUtils.setNbtInt(megaStone, "", "CustomModelData", customModelData(id));
-        NbtUtils.setNbtBoolean(megaStone, "", "italic", false);
         String displayName = id.substring(0, 1).toUpperCase() + id.substring(1);
         if (displayName.endsWith("x") || displayName.endsWith("y")) {
             displayName = displayName.substring(0, id.length() - 1) +
                 displayName.substring(id.length() - 1).toUpperCase();
         }
-        NbtUtils.setItemName(megaStone, displayName, true);
+        NbtUtils.setItemName(megaStone, displayName, false);
         return megaStone;
     }
 

--- a/common/src/main/java/com/selfdot/cobblemonmegas/common/mixin/DetailsChangeInstructionMixin.java
+++ b/common/src/main/java/com/selfdot/cobblemonmegas/common/mixin/DetailsChangeInstructionMixin.java
@@ -1,6 +1,5 @@
 package com.selfdot.cobblemonmegas.common.mixin;
 
-import com.cobblemon.mod.common.api.abilities.Ability;
 import com.cobblemon.mod.common.api.battles.interpreter.BattleMessage;
 import com.cobblemon.mod.common.api.battles.model.PokemonBattle;
 import com.cobblemon.mod.common.api.pokemon.feature.FlagSpeciesFeature;
@@ -17,9 +16,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Mixin(DetailsChangeInstruction.class)
 public abstract class DetailsChangeInstructionMixin {
@@ -47,9 +43,9 @@ public abstract class DetailsChangeInstructionMixin {
                 Pokemon originalPokemon = battlePokemon.getOriginalPokemon();
                 Pokemon effectedPokemon = battlePokemon.getEffectedPokemon();
 
-                // Save the original ability to restore it later
-                ConcurrentHashMap<UUID, Ability> originalAbilities = CobblemonMegas.getInstance().getOriginalAbilities();
-                originalAbilities.put(originalPokemon.getUuid(), originalPokemon.getAbility());
+                // Save the ability to restore it later
+                MegaUtils.savePreviousAbility(originalPokemon);
+                MegaUtils.savePreviousAbility(effectedPokemon);
 
                 new FlagSpeciesFeature(megaType, true).apply(originalPokemon);
                 new FlagSpeciesFeature(megaType, true).apply(effectedPokemon);

--- a/common/src/main/java/com/selfdot/cobblemonmegas/common/util/NbtUtils.java
+++ b/common/src/main/java/com/selfdot/cobblemonmegas/common/util/NbtUtils.java
@@ -1,5 +1,6 @@
 package com.selfdot.cobblemonmegas.common.util;
 
+import com.cobblemon.mod.common.pokemon.Pokemon;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.component.type.NbtComponent;
 import net.minecraft.item.ItemStack;
@@ -169,5 +170,30 @@ public class NbtUtils {
 
             return MutableText.of(PlainTextContent.EMPTY).append(value).setStyle(textStyle);
         });
+    }
+
+    /**
+     * Sets a string value in the persistent NBT data of the given Pokémon.
+     *
+     * @param pokemon the Pokémon to modify
+     * @param key     the NBT key to set
+     * @param value   the string value to assign
+     */
+    public static void setPokemonNbtString(@NotNull Pokemon pokemon, @NotNull String key, @NotNull String value) {
+        pokemon.getPersistentData().putString(key, value);
+        // we have to emit to update the persistent data
+        pokemon.getAnyChangeObservable().emit();
+    }
+
+    /**
+     * Removes a string value from the persistent NBT data of the given Pokémon.
+     *
+     * @param pokemon the Pokémon to modify
+     * @param key     the NBT key to remove
+     */
+    public static void removePokemonNbtString(@NotNull Pokemon pokemon, @NotNull String key) {
+        pokemon.getPersistentData().remove(key);
+        // we have to emit to update the persistent data
+        pokemon.getAnyChangeObservable().emit();
     }
 }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -34,7 +34,9 @@ dependencies {
         isTransitive = false
     }
 
-    modImplementation("com.cobblemon:fabric:${rootProject.property("cobblemon_version")}")
+    modImplementation("com.cobblemon:fabric:${rootProject.property("cobblemon_version")}") {
+        isChanging = true
+    }
 
     modImplementation(libs.fabricLoader)
     modRuntimeOnly(libs.fabricApi)
@@ -65,4 +67,5 @@ configurations.all {
     resolutionStrategy {
         force("net.fabricmc:fabric-loader:0.16.5")
     }
+    resolutionStrategy.cacheChangingModulesFor(0, TimeUnit.SECONDS)
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -29,6 +29,7 @@
     "fabric": ">=0.104.0",
     "architectury": ">=13.0.2",
     "minecraft": ">=1.21.1",
-    "java": ">=21"
+    "java": ">=21",
+    "cobblemon": ">=1.6.0"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,6 @@ cobblemon_version=1.6.0+1.21.1-SNAPSHOT
 
 archives_base_name=CobblemonMegas
 mod_id=cobblemonmegas
-mod_version=1.3.2
+mod_version=1.3.3
 snapshot=false
 maven_group=com.selfdot.cobblemonmegas


### PR DESCRIPTION
In v1.3.2 we pushed a workaround fix to restore the Pokemon abilities to its original ability after it de-mega evolves.

We used the same logic as other parts of the mod already used, which is storing the events in-memory using a ConcurrentHashMap.

Using this method, since it is all saved in memory, if a server crashes when a pokemon is mega evolved, it will lose the reference and fall back to previous versions behavior (<=1.3.1), which is: choose the first ability in the pokemon's species AbilityPool.

We decided to use the `Pokemon` own `persistentData` NBT compounds to store this information instead. This is synced with the server and we can use it to restore it to its original ability afterwards.